### PR TITLE
Initial fixes to Metal implementation

### DIFF
--- a/SyphonMetalClient.h
+++ b/SyphonMetalClient.h
@@ -8,8 +8,10 @@
 @interface SYPHON_METAL_CLIENT_UNIQUE_CLASS_NAME : SyphonClientBase
 
 
-- (id)initWithServerDescription:(NSDictionary *)description device:(id<MTLDevice>)device colorPixelFormat:(MTLPixelFormat)colorPixelFormat options:(NSDictionary *)options
-                frameHandler:(void (^)(SYPHON_METAL_CLIENT_UNIQUE_CLASS_NAME *client))handler;
+- (id)initWithServerDescription:(NSDictionary *)description
+                         device:(id<MTLDevice>)device
+                        options:(NSDictionary *)options
+                   frameHandler:(void (^)(SYPHON_METAL_CLIENT_UNIQUE_CLASS_NAME *client))handler;
 
 - (id<MTLTexture>)newFrameImage;
 - (void)stop;

--- a/SyphonMetalClient.m
+++ b/SyphonMetalClient.m
@@ -7,16 +7,16 @@
     int32_t _threadLock;
     id<MTLTexture> _frame;
     id<MTLDevice> _device;
-    MTLPixelFormat _colorPixelFormat;
 }
 
-- (id)initWithServerDescription:(NSDictionary *)description device:(id<MTLDevice>)theDevice colorPixelFormat:(MTLPixelFormat)theColorPixelFormat options:(NSDictionary *)options
+- (id)initWithServerDescription:(NSDictionary *)description
+                         device:(id<MTLDevice>)theDevice
+                        options:(NSDictionary *)options
                    frameHandler:(void (^)(SYPHON_METAL_CLIENT_UNIQUE_CLASS_NAME *client))handler
 {
     self = [super initWithServerDescription:description options:options newFrameHandler:handler];
     if( self )
     {
-        _colorPixelFormat = theColorPixelFormat;
         _device = theDevice;
         _threadLock = OS_SPINLOCK_INIT;
         _frame = nil;
@@ -50,7 +50,7 @@
     BOOL hasSizeChanged = (_frame.width != IOSurfaceGetWidth(surface) || _frame.height != IOSurfaceGetWidth(surface));
     if( _frame == nil || hasSizeChanged )
     {
-        MTLTextureDescriptor* descriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:_colorPixelFormat width:IOSurfaceGetWidth(surface) height:IOSurfaceGetHeight(surface) mipmapped:NO];
+        MTLTextureDescriptor* descriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm width:IOSurfaceGetWidth(surface) height:IOSurfaceGetHeight(surface) mipmapped:NO];
         _frame = [_device newTextureWithDescriptor:descriptor iosurface:surface plane:0];
     }
 

--- a/SyphonMetalClient.m
+++ b/SyphonMetalClient.m
@@ -4,10 +4,10 @@
 
 @implementation SYPHON_METAL_CLIENT_UNIQUE_CLASS_NAME
 {
-    int32_t threadLock;
-    id<MTLTexture> frame;
-    id<MTLDevice> device;
-    MTLPixelFormat colorPixelFormat;
+    int32_t _threadLock;
+    id<MTLTexture> _frame;
+    id<MTLDevice> _device;
+    MTLPixelFormat _colorPixelFormat;
 }
 
 - (id)initWithServerDescription:(NSDictionary *)description device:(id<MTLDevice>)theDevice colorPixelFormat:(MTLPixelFormat)theColorPixelFormat options:(NSDictionary *)options
@@ -16,10 +16,10 @@
     self = [super initWithServerDescription:description options:options newFrameHandler:handler];
     if( self )
     {
-        colorPixelFormat = theColorPixelFormat;
-        device = theDevice;
-        threadLock = OS_SPINLOCK_INIT;
-        frame = nil;
+        _colorPixelFormat = theColorPixelFormat;
+        _device = theDevice;
+        _threadLock = OS_SPINLOCK_INIT;
+        _frame = nil;
     }
     return self;
 }
@@ -32,9 +32,9 @@
 
 - (void)stop
 {
-    OSSpinLockLock(&threadLock);
-    frame = nil;
-    OSSpinLockUnlock(&threadLock);
+    OSSpinLockLock(&_threadLock);
+    _frame = nil;
+    OSSpinLockUnlock(&_threadLock);
     [super stop];
 }
 
@@ -47,14 +47,14 @@
         SYPHONLOG(@"surface is nil !");
         return nil;
     }
-    BOOL hasSizeChanged = (frame.width != IOSurfaceGetWidth(surface) || frame.height != IOSurfaceGetWidth(surface));
-    if( frame == nil || hasSizeChanged )
+    BOOL hasSizeChanged = (_frame.width != IOSurfaceGetWidth(surface) || _frame.height != IOSurfaceGetWidth(surface));
+    if( _frame == nil || hasSizeChanged )
     {
-        MTLTextureDescriptor* descriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:colorPixelFormat width:IOSurfaceGetWidth(surface) height:IOSurfaceGetHeight(surface) mipmapped:NO];
-        frame = [device newTextureWithDescriptor:descriptor iosurface:surface plane:0];
+        MTLTextureDescriptor* descriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:_colorPixelFormat width:IOSurfaceGetWidth(surface) height:IOSurfaceGetHeight(surface) mipmapped:NO];
+        _frame = [_device newTextureWithDescriptor:descriptor iosurface:surface plane:0];
     }
 
-    return [frame retain];
+    return [_frame retain];
 }
 
 @end

--- a/SyphonMetalServer.h
+++ b/SyphonMetalServer.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 #define SYPHON_METAL_SERVER_UNIQUE_CLASS_NAME SYPHON_UNIQUE_CLASS_NAME(SyphonMetalServer)
 @interface SYPHON_METAL_SERVER_UNIQUE_CLASS_NAME : SyphonServerBase
 
-- (id)initWithName:(NSString*)name device:(id<MTLDevice>)device colorPixelFormat:(MTLPixelFormat)colorPixelFormat options:(NSDictionary *)options;
+- (id)initWithName:(NSString*)name device:(id<MTLDevice>)device options:(NSDictionary *)options;
 
 // API Method 1
 - (void)drawFrame:(void(^)(id<MTLTexture> texture,id<MTLCommandBuffer> commandBuffer))frameHandler size:(NSSize)size commandBuffer:(id<MTLCommandBuffer>)commandBuffer;

--- a/SyphonMetalServer.m
+++ b/SyphonMetalServer.m
@@ -16,7 +16,7 @@
     self = [super initWithName:name options:options];
     if( self )
     {
-        _device = theDevice;
+        _device = [theDevice retain];
         _commandQueue = [_device newCommandQueue];
         _surfaceTexture = nil;
     }
@@ -47,6 +47,8 @@
 - (void)stop
 {
     _surfaceTexture = nil;
+    [_device release];
+    _device = nil;
     [super stop];
 }
 

--- a/SyphonMetalServer.m
+++ b/SyphonMetalServer.m
@@ -6,19 +6,17 @@
 {
     id <MTLTexture> _surfaceTexture;
     id<MTLDevice> _device;
-    MTLPixelFormat _colorPixelFormat;
     id<MTLCommandQueue> _commandQueue;
 }
 
 #pragma mark - Lifecycle
 
-- (id)initWithName:(NSString *)name device:(id<MTLDevice>)theDevice colorPixelFormat:(MTLPixelFormat)theColorPixelFormat options:(NSDictionary *)options
+- (id)initWithName:(NSString *)name device:(id<MTLDevice>)theDevice options:(NSDictionary *)options
 {
     self = [super initWithName:name options:options];
     if( self )
     {
         _device = theDevice;
-        _colorPixelFormat = theColorPixelFormat;
         _commandQueue = [_device newCommandQueue];
         _surfaceTexture = nil;
     }
@@ -30,7 +28,7 @@
     BOOL hasSizeChanged = !NSEqualSizes(CGSizeMake(_surfaceTexture.width, _surfaceTexture.height), size);
     if( _surfaceTexture == nil || hasSizeChanged )
     {
-        MTLTextureDescriptor *descriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:_colorPixelFormat
+        MTLTextureDescriptor *descriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
                                                                                               width:size.width
                                                                                              height:size.height
                                                                                           mipmapped:NO];


### PR DESCRIPTION
1. use Syphon's convention for naming instance variables (initial _underscore).
2. delete the colorPixelFormat argument to the server and client's initializers - the format passed to create the Metal texture must describe the contents of the IOSurface, which is fixed by Syphon.
3. SyphonMetalClient did not correctly invalidate its texture, now it does
4. retain the MTLDevice for as long as SyphonMetalServer/Client might use it
5. there were a lot of leaks, I fixed them